### PR TITLE
chore: code block language tag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install @daniel.husar/gatsby-theme-spring
 
 Add plugin to you gatsby config:
 
-```js!gatsby-config.js
+```js:title=gatsby-config.js
 module.exports = {
   siteMetadata: {
     ...


### PR DESCRIPTION
This is to silence prism highlighter warnings. Thanks!