### PR TITLE
fixed fenced code w/ title

### DIFF
--- a/demo/src/blog/installation.mdx
+++ b/demo/src/blog/installation.mdx
@@ -24,7 +24,7 @@ npm install @daniel.husar/gatsby-theme-spring
 
 Add plugin to you gatsby config:
 
-```js!gatsby-config.js
+```js:title=gatsby-config.js
 module.exports = {
   siteMetadata: {
     ...

--- a/theme/README.md
+++ b/theme/README.md
@@ -84,10 +84,10 @@ draft: false
 ### Features
 
  - [Gallery layout](https://gatsby-theme-spring.netlify.com//components/#gallery)
- - [Code samples with live edit](https://gatsby-theme-spring.netlify.com// components#simple-javascript-code-sample)
+ - [Code samples with live edit](https://gatsby-theme-spring.netlify.com//components/#simple-javascript-code-sample)
  - [Monospaced font with programming ligatures](https://github.com/tonsky/FiraCode)
  - MDX with batteries included
- - [Open graph support](https://developers.facebook.com/tools/debug/sharing/ q=https%3A%2F%2Fgatsby-theme-spring.netlify.com%2Ftypography%2F)
+ - [Open graph support](https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fgatsby-theme-spring.netlify.com%2Ftypography%2F)
  - Responsive
  - [Accessibility report](https://travis-ci.org/danielhusar/gatsby-theme-spring/ jobs/565790587)
  - Works without javascript

--- a/theme/README.md
+++ b/theme/README.md
@@ -24,7 +24,7 @@ npm install @daniel.husar/gatsby-theme-spring
 
 Add plugin to you gatsby config:
 
-```js!gatsby-config.js
+```js:title=gatsby-config.js
 module.exports = {
   siteMetadata: {
     ...
@@ -43,8 +43,8 @@ module.exports = {
 
 Plugin accepts 2 options:
 
- - `paginationOffset` (number) - number of articles per page
- - `author` (string) - author name for the rss feed
+- `paginationOffset` (number) - number of articles per page
+- `author` (string) - author name for the rss feed
 
 I recommend populating also `siteMetadata` with those properties:
 
@@ -75,27 +75,27 @@ draft: false
 ---
 ```
 
- - `url` - Post url
- - `date` - Post date
- - `title` - Post title
- - `banner` - Post banner image. To disable image set this to null.
- - `draft` - If post should be in draft mode.
+- `url` - Post url
+- `date` - Post date
+- `title` - Post title
+- `banner` - Post banner image. To disable image set this to null.
+- `draft` - If post should be in draft mode.
 
 ### Features
 
- - [Gallery layout](https://gatsby-theme-spring.netlify.com//components/#gallery)
- - [Code samples with live edit](https://gatsby-theme-spring.netlify.com//components/#simple-javascript-code-sample)
- - [Monospaced font with programming ligatures](https://github.com/tonsky/FiraCode)
- - MDX with batteries included
- - [Open graph support](https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fgatsby-theme-spring.netlify.com%2Ftypography%2F)
- - Responsive
- - [Accessibility report](https://travis-ci.org/danielhusar/gatsby-theme-spring/jobs/565790587)
- - Works without javascript
- - Written in Typescript
- - [RSS feed](https://gatsby-theme-spring.netlify.com//rss.xml)
- - [Sitemap](https://gatsby-theme-spring.netlify.com//sitemap.xml)
- - Pagination
- - Drafts
+- [Gallery layout](https://gatsby-theme-spring.netlify.com//components/#gallery)
+- [Code samples with live edit](https://gatsby-theme-spring.netlify.com//components#simple-javascript-code-sample)
+- [Monospaced font with programming ligatures](https://github.com/tonsky/FiraCode)
+- MDX with batteries included
+- [Open graph support](https://developers.facebook.com/tools/debug/sharing/q=https%3A%2F%2Fgatsby-theme-spring.netlify.com%2Ftypography%2F)
+- Responsive
+- [Accessibility report](https://travis-ci.org/danielhusar/gatsby-theme-spring/jobs565790587)
+- Works without javascript
+- Written in Typescript
+- [RSS feed](https://gatsby-theme-spring.netlify.com//rss.xml)
+- [Sitemap](https://gatsby-theme-spring.netlify.com//sitemap.xml)
+- Pagination
+- Drafts
 
 ### License
 

--- a/theme/README.md
+++ b/theme/README.md
@@ -43,8 +43,8 @@ module.exports = {
 
 Plugin accepts 2 options:
 
-- `paginationOffset` (number) - number of articles per page
-- `author` (string) - author name for the rss feed
+ - `paginationOffset` (number) - number of articles per page
+ - `author` (string) - author name for the rss feed
 
 I recommend populating also `siteMetadata` with those properties:
 
@@ -75,27 +75,27 @@ draft: false
 ---
 ```
 
-- `url` - Post url
-- `date` - Post date
-- `title` - Post title
-- `banner` - Post banner image. To disable image set this to null.
-- `draft` - If post should be in draft mode.
+ - `url` - Post url
+ - `date` - Post date
+ - `title` - Post title
+ - `banner` - Post banner image. To disable image set this to null.
+ - `draft` - If post should be in draft mode.
 
 ### Features
 
-- [Gallery layout](https://gatsby-theme-spring.netlify.com//components/#gallery)
-- [Code samples with live edit](https://gatsby-theme-spring.netlify.com//components#simple-javascript-code-sample)
-- [Monospaced font with programming ligatures](https://github.com/tonsky/FiraCode)
-- MDX with batteries included
-- [Open graph support](https://developers.facebook.com/tools/debug/sharing/q=https%3A%2F%2Fgatsby-theme-spring.netlify.com%2Ftypography%2F)
-- Responsive
-- [Accessibility report](https://travis-ci.org/danielhusar/gatsby-theme-spring/jobs565790587)
-- Works without javascript
-- Written in Typescript
-- [RSS feed](https://gatsby-theme-spring.netlify.com//rss.xml)
-- [Sitemap](https://gatsby-theme-spring.netlify.com//sitemap.xml)
-- Pagination
-- Drafts
+ - [Gallery layout](https://gatsby-theme-spring.netlify.com//components/#gallery)
+ - [Code samples with live edit](https://gatsby-theme-spring.netlify.com// components#simple-javascript-code-sample)
+ - [Monospaced font with programming ligatures](https://github.com/tonsky/FiraCode)
+ - MDX with batteries included
+ - [Open graph support](https://developers.facebook.com/tools/debug/sharing/ q=https%3A%2F%2Fgatsby-theme-spring.netlify.com%2Ftypography%2F)
+ - Responsive
+ - [Accessibility report](https://travis-ci.org/danielhusar/gatsby-theme-spring/ jobs/565790587)
+ - Works without javascript
+ - Written in Typescript
+ - [RSS feed](https://gatsby-theme-spring.netlify.com//rss.xml)
+ - [Sitemap](https://gatsby-theme-spring.netlify.com//sitemap.xml)
+ - Pagination
+ - Drafts
 
 ### License
 

--- a/theme/README.md
+++ b/theme/README.md
@@ -89,7 +89,7 @@ draft: false
  - MDX with batteries included
  - [Open graph support](https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fgatsby-theme-spring.netlify.com%2Ftypography%2F)
  - Responsive
- - [Accessibility report](https://travis-ci.org/danielhusar/gatsby-theme-spring/ jobs/565790587)
+ - [Accessibility report](https://travis-ci.org/danielhusar/gatsby-theme-spring/jobs/565790587)
  - Works without javascript
  - Written in Typescript
  - [RSS feed](https://gatsby-theme-spring.netlify.com//rss.xml)


### PR DESCRIPTION
Hi, I created a PR to fix some of your markdown code fence as it was throwing a `warn unable to find prism language 'js!gatsby-config.js' for highlighting. applying generic code block` in [gatsby repo](https://github.com/gatsbyjs/gatsby).

I changed ` ```js!gatsby-config.js` to ` ```js:title=gatsby-config.js`, which is what I think you intended to do.

Addresses:
- https://github.com/gatsbyjs/gatsby/issues/14282
- https://github.com/gatsbyjs/gatsby/pull/17476