### PR TITLE
Add `alt` text for hero images

### DIFF
--- a/theme/src/components/hero.tsx
+++ b/theme/src/components/hero.tsx
@@ -8,18 +8,19 @@ import { ImageSharpFluid } from '../types/graphql-types';
 interface Props {
   src: ImageSharpFluid;
   url?: string;
+  alt?: string;
 }
 
-export default function Hero({ src, url }: Props) {
+export default function Hero({ src, url, alt }: Props) {
   if (!src) return null;
 
   return (
     <HeroStyled>
       <Spacer size={1} />
       {url ? (
-        <Link to={url}>
-          <Img sizes={src} />
-        </Link>
+        <Link to={url}>{alt ? <Img sizes={src} alt={alt} /> : <Img sizes={src} />}</Link>
+      ) : alt ? (
+        <Img sizes={src} alt={alt} />
       ) : (
         <Img sizes={src} />
       )}

--- a/theme/src/components/post-summary.tsx
+++ b/theme/src/components/post-summary.tsx
@@ -21,10 +21,10 @@ export default function PostSummary({ post }: Props) {
         <Link to={post.fields.url}>{post.fields.title}</Link>
       </H2>
 
-      {hero && post.fields.url && (
+      {hero && post.fields.url && post.fields.title && (
         <>
           <Spacer size={0.5} />
-          <Hero src={hero} url={post.fields.url} />
+          <Hero src={hero} url={post.fields.url} alt={post.fields.title} />
         </>
       )}
       {post.timeToRead != null && (

--- a/theme/src/components/post.tsx
+++ b/theme/src/components/post.tsx
@@ -24,7 +24,7 @@ export default function Post({ post }: Props) {
       {banner && (
         <>
           <Spacer size={1.5} />
-          <Hero src={banner} />
+          <Hero src={banner} alt={post.fields.title} />
         </>
       )}
       {post.timeToRead != null && (


### PR DESCRIPTION
Add an `alt` property to the `Hero` component to pass to the underlying `Img` component for displaying alternate text.

The `PostSummary` and `Post` components have been updated to pass `post.fields.title` to the new `alt` property.

Addresses the following issue picked up by the Lighthouse Accessibility audit:
- Links do not have a discernible name

See: https://web.dev/link-name